### PR TITLE
Prevent friend structs from appearing in the docs:

### DIFF
--- a/example/xsl/config.xsl
+++ b/example/xsl/config.xsl
@@ -2,5 +2,5 @@
 <xsl:variable name="doc-ref" select="'docca.ref'"/>
 <xsl:variable name="doc-ns" select="'example'"/>
 <xsl:variable name="debug" select="0"/>
-<xsl:variable name="private" select="0"/>
+<xsl:variable name="include-private-members" select="false()"/>
 <!-- End Variables -->

--- a/include/docca/base-stage1.xsl
+++ b/include/docca/base-stage1.xsl
@@ -121,7 +121,7 @@
                             | innerclass[@prot eq 'public'][not(d:should-ignore-inner-class(.))]"
                       tunnel="yes"/>
       <xsl:with-param name="friends"
-                      select="sectiondef[@kind eq 'friend']/memberdef[not(type eq 'friend class')]
+                      select="sectiondef[@kind eq 'friend']/memberdef[not(type = ('friend class','friend struct'))]
                                                                      [not(d:should-ignore-friend(.))]"
                       tunnel="yes"/>
     </xsl:next-match>

--- a/include/docca/config.xsl
+++ b/include/docca/config.xsl
@@ -15,8 +15,6 @@
     <replace pattern="BOOST_ASIO_DECL ?(.*)" with="$1"/>
   </xsl:variable>
 
-  <xsl:variable name="include-private-members" select="false()"/>
-
   <!-- TODO: refactor the stage-two-specific rules into a separate module that can't intefere with stage one -->
   <xsl:template mode="includes-template" match="location"
     >Defined in header [include_file {substring-after(@file, 'include/')}]


### PR DESCRIPTION
fix #48, fix #54

Also, move $include-private-members definition to project-specific config file.