### PR TITLE
Include usage requirement for reference target

### DIFF
--- a/docca.jam
+++ b/docca.jam
@@ -9,13 +9,17 @@
 #
 
 
+import "class" : new ;
 import doxygen ;
 import param ;
 import path ;
 import project ;
+import property-set ;
 import quickbook ;
 import saxonhe ;
 import sequence ;
+import toolset ;
+import type ;
 
 
 .here  = [ path.make [ modules.binding $(__name__) ] ] ;
@@ -141,7 +145,7 @@ rule reference ( target : sources * : requirements * : default-build *
         : $(requirements)
         ;
 
-    make $(target)
+    generate $(target)
         : $(target-dir)/xml-pages.xml
           $(target-dir)/assemble-quickbook.xsl
 
@@ -149,10 +153,31 @@ rule reference ( target : sources * : requirements * : default-build *
           #       rather than relying on it being hard-coded
           #       in the XSLT (which it is!)
           $(target-dir)/stage2/results
-        : @saxonhe.saxonhe
-        : $(requirements)
+        : <generating-rule>@docca.make-qbk
+          $(requirements)
+        : $(default-build)
         : $(usage-requirements)
         ;
+}
+
+
+rule make-qbk ( project name : property-set : sources * )
+{
+        local action-name = saxonhe.saxonhe ;
+        local relevant = [ toolset.relevant $(action-name) ] ;
+        local action = [
+              new action $(sources)
+            : $(action-name)
+            : [ $(property-set).relevant $(relevant) ]
+            ] ;
+        local target = [
+              new file-target $(name) exact
+            : [ type.type $(name) ]
+            : $(project)
+            : $(action)
+            ] ;
+        local path = [ path.root $(name) [ $(target).path ] ] ;
+        return [ property-set.create <include>$(path:D) ] $(target) ;
 }
 
 

--- a/example/Jamfile
+++ b/example/Jamfile
@@ -69,11 +69,6 @@ docca.reference reference.qbk
 #        saxonhe.saxonhe
 #    ;
 
-# We have to make a copy of reference.qbk and put it
-# in a place where the static .qbk files can find it
-#
-install qbk : reference.qbk ;
-
 #-------------------------------------------------------------------------------
 #
 # Produce the Boost.Book XML from the QuickBook
@@ -92,8 +87,8 @@ xml json_doc
     :
         main.qbk
     :
+        <use>reference.qbk
         <dependency>images
-        <dependency>qbk
     ;
 
 explicit json_doc ;

--- a/example/main.qbk
+++ b/example/main.qbk
@@ -25,7 +25,7 @@
 [template include_file[path][^<'''<ulink url="https://github.com/boostorg/docca/blob/master/example/include/'''[path]'''">'''[path]'''</ulink>'''>]]
 
 [section:ref Reference]
-[include qbk/reference.qbk]
+[include reference.qbk]
 [endsect]
 
 [xinclude index.xml]


### PR DESCRIPTION
This allows to remove yet another target from users' jamfiles. Instead of requiring them to copy reference quickbook file into their sources, we add include directory to usage requirements. @evanlenz can you test it on your machine, so that I know that it works properly on Windows?