### PR TITLE
Get rid of undesired "Description" headings

### DIFF
--- a/example/include/docca/issue_109.hpp
+++ b/example/include/docca/issue_109.hpp
@@ -1,0 +1,32 @@
+//
+// Copyright (c) 2022 Evan Lenz (evan@lenzconsulting.com)
+//
+// Distributed under the Boost Software License, Version 1.0. (See accompanying
+// file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+//
+
+#ifndef EXAMPLE_ISSUE_109_HPP
+#define EXAMPLE_ISSUE_109_HPP
+
+namespace example {
+
+/** Issue 109
+
+    Properly detect (and omit) empty description sections when
+    Doxygen puts simplesect elements inside the detaileddescription.
+*/
+class issue_109
+{
+public:
+    /** Constructor
+
+        @par Test section
+
+            Test paragraph
+    */
+    issue_109();
+};
+
+} // example
+
+#endif

--- a/example/include/docca/issue_117.hpp
+++ b/example/include/docca/issue_117.hpp
@@ -1,0 +1,31 @@
+//
+// Copyright (c) 2022 Evan Lenz (evan@lenzconsulting.com)
+//
+// Distributed under the Boost Software License, Version 1.0. (See accompanying
+// file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+//
+
+#ifndef EXAMPLE_ISSUE_117_HPP
+#define EXAMPLE_ISSUE_117_HPP
+
+namespace example {
+
+/** Issue 117
+
+    Properly detect (and omit) empty description sections, even when
+    Doxygen puts the param list inside the detaileddescription.
+*/
+class issue_117
+{
+public:
+    /** Construct from an array of bytes.
+
+        @param bytes The value to construct from.
+    */
+    issue_117(
+        bytes_type const& bytes) noexcept;
+};
+
+} // example
+
+#endif

--- a/include/docca/base-stage1.xsl
+++ b/include/docca/base-stage1.xsl
@@ -213,7 +213,24 @@
   <xsl:template mode="section" match="simplesect[matches(title,'Concepts:?')]"/>
 
   <!-- Omit description section if it has no body -->
-  <xsl:template mode="section" match="detaileddescription[not(normalize-space(.))]" priority="1"/>
+  <xsl:template mode="section" match="detaileddescription[not(normalize-space(.))]" priority="2"/>
+
+  <!-- Omit the "Description" heading (only show the body) if it has nothing but a parameterlist -->
+  <xsl:template mode="section" match="detaileddescription[not(normalize-space(d:strip-parameterlist(.)))]" priority="1">
+    <xsl:apply-templates mode="section-body" select="."/>
+  </xsl:template>
+
+          <xsl:function name="d:strip-parameterlist" as="element(detaileddescription)">
+            <xsl:param name="desc" as="element(detaileddescription)"/>
+            <xsl:apply-templates mode="strip-parameterlist" select="$desc"/>
+          </xsl:function>
+
+                  <xsl:template mode="strip-parameterlist" match="parameterlist"/>
+                  <xsl:template mode="strip-parameterlist" match="@* | node()">
+                    <xsl:copy>
+                      <xsl:apply-templates mode="#current" select="@* | node()"/>
+                    </xsl:copy>
+                  </xsl:template>
 
   <xsl:template mode="section" match="*">
     <section>

--- a/include/docca/base-stage1.xsl
+++ b/include/docca/base-stage1.xsl
@@ -215,18 +215,18 @@
   <!-- Omit description section if it has no body -->
   <xsl:template mode="section" match="detaileddescription[not(normalize-space(.))]" priority="2"/>
 
-  <!-- Omit the "Description" heading (only show the body) if it has nothing but a parameterlist -->
-  <xsl:template mode="section" match="detaileddescription[not(normalize-space(d:strip-parameterlist(.)))]" priority="1">
+  <!-- Omit the "Description" heading (only show the body) if it has nothing but a parameterlist or simplesect -->
+  <xsl:template mode="section" match="detaileddescription[not(normalize-space(d:strip-sections(.)))]" priority="1">
     <xsl:apply-templates mode="section-body" select="."/>
   </xsl:template>
 
-          <xsl:function name="d:strip-parameterlist" as="element(detaileddescription)">
+          <xsl:function name="d:strip-sections" as="element(detaileddescription)">
             <xsl:param name="desc" as="element(detaileddescription)"/>
-            <xsl:apply-templates mode="strip-parameterlist" select="$desc"/>
+            <xsl:apply-templates mode="strip-sections" select="$desc"/>
           </xsl:function>
 
-                  <xsl:template mode="strip-parameterlist" match="parameterlist"/>
-                  <xsl:template mode="strip-parameterlist" match="@* | node()">
+                  <xsl:template mode="strip-sections" match="parameterlist | simplesect"/>
+                  <xsl:template mode="strip-sections" match="@* | node()">
                     <xsl:copy>
                       <xsl:apply-templates mode="#current" select="@* | node()"/>
                     </xsl:copy>


### PR DESCRIPTION
This fixes about 60 instances of #117 in the Beast project, such as [this method page](https://www.boost.org/doc/libs/1_73_0/libs/beast/doc/html/beast/ref/boost__beast__file_stdio/write.html) and [this overload page](https://www.boost.org/doc/libs/1_73_0/libs/beast/doc/html/beast/ref/boost__beast__buffered_read_stream/buffered_read_stream/overload1.html).

And many more instances of #109 in json, Beast, and URL.