### PR TITLE
omit extra header when description starts with a parameter table

### DIFF
--- a/include/docca/quickbook/components.jinja2
+++ b/include/docca/quickbook/components.jinja2
@@ -363,10 +363,7 @@ Official repository: https://github.com/boostorg/json
 ```
 {{ caller("summary") }}
 {% if entity.description -%}
-{% if entity.description[0] is not Section -%}
-    {{ heading('Description') }}
-{%- endif %}
-{{ description(entity.description) }}
+{{ description(entity.description, title='Description') }}
 {%- endif %}
 
 {% if Config.get('convenience_header')
@@ -628,9 +625,13 @@ static
 {%- endmacro %}
 
 
-{% macro description(parts, nesting='') -%}
-
+{% macro description(parts, nesting='', title=None) -%}
 {%- for part in parts -%}
+{%- if loop.first and title
+    and part is not Section and part is not ParameterList
+    -%}
+    {{ heading(title) }}
+{% endif -%}
 
 {%- if part is Paragraph -%}
 {{ phrase(part) }}

--- a/test/docca_qbk_test.py
+++ b/test/docca_qbk_test.py
@@ -590,8 +590,7 @@ def test_description(render):
     render.template = '''
         {%- import "docca/quickbook/components.jinja2" as qbk -%}
         {{ qbk.description(entities, nesting='  ') }}'''
-    parts = []
-    assert render(parts) == ''
+    assert render([]) == ''
 
     parts = [
         docca.Paragraph([ '1 ', docca.Monospaced(['2']) ]),
@@ -696,6 +695,70 @@ def test_description(render):
             ]
           ]
         ]
+        [heading Parameters]
+        [table [[Name][Description]]
+          [
+            [`int a`, `char const* b`
+            ]
+            [
+        param1 description
+
+
+            ]
+          ]
+          [
+            [`float c`
+            ]
+            [
+        param2 description
+
+
+            ]
+          ]
+        ]
+
+        ''')
+
+    render.template = '''\
+        {%- import "docca/quickbook/components.jinja2" as qbk -%}
+        {{ qbk.description(entities, nesting='  ', title='Title') }}'''
+    assert render([]) == ''
+
+    parts = [ docca.Paragraph([ '1 ', docca.Monospaced(['2']) ]) ]
+    assert render(parts) == textwrap.dedent('''\
+        [heading Title]
+        1 `2`
+
+        ''')
+    parts = [
+        docca.ParameterList(
+            'param',
+            [
+                docca.ParameterDescription(
+                    [docca.Paragraph(['param1 description'])],
+                    [
+                        docca.ParameterItem(
+                            docca.Phrase(['int']),
+                            docca.Phrase(['a']),
+                            None),
+                        docca.ParameterItem(
+                            docca.Phrase(['char const*']),
+                            docca.Phrase(['b']),
+                            None),
+                    ],
+                ),
+                docca.ParameterDescription(
+                    [docca.Paragraph(['param2 description'])],
+                    [
+                        docca.ParameterItem(
+                            docca.Phrase(['float']),
+                            docca.Phrase(['c']),
+                            None),
+                    ]
+                ),
+            ])
+    ]
+    assert render(parts) == textwrap.dedent('''\
         [heading Parameters]
         [table [[Name][Description]]
           [


### PR DESCRIPTION
Fix #175 