### PR TITLE
allow enabling showing defaulted functions

### DIFF
--- a/include/docca/quickbook.jinja2
+++ b/include/docca/quickbook.jinja2
@@ -25,6 +25,8 @@ In adition:
     namespace.
 * It uses "link_prefix" Config key as prefix for every generated cross-link.
 * It uses "convenience_header" Config key for "Convenience Header" subsections.
+* It uses "show_defaulted" Config key to determine whether to display if a
+  function was explicitly defaulted (`= default`).
 * It uses "replace_strings" Config key to replace certain text strings. E.g.
   "replace_strings": { "__see_below__": "``['see-below]``" } replaces all
   occurances of the string "__see_below__" with the string "``['see-below]``"

--- a/include/docca/quickbook/components.jinja2
+++ b/include/docca/quickbook/components.jinja2
@@ -421,7 +421,7 @@ explicit
 {%- if entity.is_noexcept and not entity.is_destructor %} noexcept{% endif -%}
 {%- if not entity.is_noexcept and entity.is_destructor %} noexcept(false){% endif -%}
 {%- if entity.is_deleted %} = delete
-{%- elif entity.is_defaulted %} = default
+{%- elif entity.is_defaulted and Config.get('show_defaulted') %} = default
 {%- endif -%}
 ;
 {%- endmacro %}


### PR DESCRIPTION
Explicitly defaulted functions (= default) used to be marked in the output. Now this is disabled by default, but can be ebabled a config parameter,

Fix #176 