### PR TITLE
do not escape ref link text in descriptions

### DIFF
--- a/include/docca/quickbook/components.jinja2
+++ b/include/docca/quickbook/components.jinja2
@@ -687,7 +687,7 @@ static
             [link {{ link(part.entity, prefer_overload=True) }}
         {%- endif -%}
         {%- if in_code %} [^{{ abridged_fqn(part.entity) }}]]``
-        {%- else %} `{{ phrase(part) }}`]
+        {%- else %} `{{ phrase(part, in_code=True) }}`]
         {%- endif -%}
     {%- elif part is UrlLink -%}
         [@{{ part.url }} {{ phrase(part, in_code=in_code) }}]

--- a/test/docca_qbk_test.py
+++ b/test/docca_qbk_test.py
@@ -568,13 +568,17 @@ def test_phrase(entities, cfg, render):
         docca.Linebreak(),
         docca.EntityRef(entities['ostream'], ['output stream']),
         docca.Phrase([' ', 'more text']),
+        docca.Linebreak(),
+        docca.EntityRef(entities['o[]'], 'operator[]'),
     ]
     assert render(parts) == textwrap.dedent('''\
         regular text `monospaced text` ['emph [*bold]]
 
         [@http://a.b/c link text][link ns1__ns2__klass.g `ref text`]
 
-        [@http://ostream.org `output stream`] more text''')
+        [@http://ostream.org `output stream`] more text
+
+        [link ns1__ns2__klass.operator__lb__rb_ `operator[]`]''')
 
     render.template = '''
         {%- import "docca/quickbook/components.jinja2" as qbk -%}
@@ -584,7 +588,9 @@ def test_phrase(entities, cfg, render):
 
         [@http://a.b/c link text]``[link ns1__ns2__klass.g [^ns1::ns2::klass::g]]``
 
-        ``[@http://ostream.org [^std::ostream]]`` more text''')
+        ``[@http://ostream.org [^std::ostream]]`` more text
+
+        ``[link ns1__ns2__klass.operator__lb__rb_ [^ns1::ns2::klass::operator\[\]]]``''')
 
 def test_description(render):
     render.template = '''


### PR DESCRIPTION
Fix #174 